### PR TITLE
Fix errors with Wireshark 3.0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,18 +47,16 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-register_dissector_files(plugin.c
+register_plugin_files(plugin.c
 	plugin
 	${DISSECTOR_SRC}
 )
 
-add_plugin_library(rsocket)
+add_plugin_library(rsocket epan)
 
-install(TARGETS rsocket
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION} NAMELINK_SKIP
-	RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION}
-)
+target_link_libraries(rsocket epan)
+
+install_plugin(rsocket epan)
 
 file(GLOB DISSECTOR_HEADERS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
 CHECKAPI(

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently it supports all RSocket frames, except resumption.
 # Build
 
 - Download Wireshark source-code.
-- Create __rsocket__ directory inside __wireshark/plugins__ folder.
+- Create __rsocket__ directory inside __wireshark/plugins/epan__ folder.
 - Download/Clone source code from this repo into the __rsocket__ folder.
 - Inside __wireshark__ folder, create __CMakeListsCustom.txt__ and add the line.
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently it supports all RSocket frames, except resumption.
 - Download/Clone source code from this repo into the __rsocket__ folder.
 - Inside __wireshark__ folder, create __CMakeListsCustom.txt__ and add the line.
 ```
-set(CUSTOM_PLUGIN_SRC_DIR plugins/rsocket)
+set(CUSTOM_PLUGIN_SRC_DIR plugins/epan/rsocket)
 ```
 - Follow the build instructions of Wireshark for your OS setup
 - Copy the built rsocket.so to the Plugins folder of wireshark. This depends on OS - on macOS it is typically ~/.config/wireshark/plugins or ~/.wireshark/plugins.

--- a/packet-rsocket.c
+++ b/packet-rsocket.c
@@ -234,8 +234,7 @@ static gint read_rsocket_req_n_frame(packet_info *pinfo, proto_tree *tree,
   return offset;
 }
 
-static gint read_rsocket_cancel_frame(proto_tree *tree, tvbuff_t *tvb,
-                                      gint offset) {
+static gint read_rsocket_cancel_frame(gint offset) {
   // no special flags
   offset += 2;
   // no other content
@@ -324,7 +323,7 @@ static int dissect_rsocket(tvbuff_t *tvb, packet_info *pinfo,
   } else if (frame_type == 0x08) {
     offset = read_rsocket_req_n_frame(pinfo, rframe_tree, tvb, offset);
   } else if (frame_type == 0x09) {
-    offset = read_rsocket_cancel_frame(rframe_tree, tvb, offset);
+    offset = read_rsocket_cancel_frame(offset);
   } else if (frame_type == 0x0A) {
     offset = read_rsocket_payload_frame(rframe_tree, tvb, offset);
   } else if (frame_type == 0x0B) {


### PR DESCRIPTION
I couldn't build with Wireshark 3.0.6, so I fixed some errors.
After applying this fix, I was able to use this plugin.

I referred to these.
https://ask.wireshark.org/question/3748/cmake-steps-for-c-dissector-24-26-migration-eg-linker-errors/
https://github.com/wireshark/wireshark/blob/wireshark-3.0.6/CMakeListsCustom.txt.example
https://github.com/wireshark/wireshark/blob/wireshark-3.0.6/plugins/epan/pluginifdemo/CMakeLists.txt

And on macOS,  I copied `rsocket.so` to `/Applications/Wireshark.app/Contents/PlugIns/wireshark/3-0/epan/`.
https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html